### PR TITLE
regular user can no longer update their own profile

### DIFF
--- a/iot_api/user_api/resources/endpoints.py
+++ b/iot_api/user_api/resources/endpoints.py
@@ -232,9 +232,9 @@ class UserInfoAPI(Resource):
 
         if not current_user:
             return internal("User {0} could not be found.".format(username.lower()))
-        # restrict user update to user admin, super admin and profile owner
+        
+        # restrict user update to user admin, super admin
         if not is_admin_user(user.id):
-            if current_user.username != user.username:
                 return forbidden()
 
         if not user.active:


### PR DESCRIPTION
Regular user was able to update their role and become an admin. To fix this, a regular user can no longer access the endpoint that updates a user's profile.

## Changes proposal
- Regular user can no longer update their profile