### PR TITLE
fix parameter parsing in /devices/count endpoint

### DIFF
--- a/iot_api/user_api/resources/endpoints.py
+++ b/iot_api/user_api/resources/endpoints.py
@@ -1938,7 +1938,7 @@ class DevicesListCountAPI(Resource):
         page = request.args.get('page')
         size = request.args.get('size')
         group_by = request.args.get('group_by')
-        data_collector = request.args.get('data_collector[]')
+        data_collector = request.args.getlist('data_collector[]')
 
         if since:
             try:


### PR DESCRIPTION
Fixed devices count (from dashboard)

## Changes proposal
 - changed parsing funtion from get() to getlist() on `/devices/count` endpoint for `data_collector` parameter

## Related Issues

https://trello.com/c/S1X2Ki8s/867-el-conteo-de-devices-en-el-dashboard-muestra-n%C3%BAmeros-erroneos-al-filtrar-por-ds

## Testing

With Postman, requested several times the counter to the defined endpoint, with several test cases (with and without `data_collector` parameter)

