### PR TITLE
Feature/retrieve ttn user gateways

### DIFF
--- a/iot_api/__init__.py
+++ b/iot_api/__init__.py
@@ -12,6 +12,7 @@ from flask_bcrypt import Bcrypt
 from flask_mail import Mail
 from iot_api import config
 from cryptography.fernet import Fernet
+from flask_session import Session
 import pika
 import os, sys
 from flask_socketio import SocketIO
@@ -27,6 +28,9 @@ app.config['JWT_BLACKLIST_ENABLED'] = True
 app.config['JWT_BLACKLIST_TOKEN_CHECKS'] = ['access', 'refresh']
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['TEMPLATES_AUTO_RELOAD'] = True
+
+app.config['SESSION_TYPE'] = 'filesystem'
+Session(app)
 
 try:
     app.config['SECRET'] = os.environ['SECRET']

--- a/iot_api/iotservice.py
+++ b/iot_api/iotservice.py
@@ -86,6 +86,8 @@ api.add_resource(res.DataCollectorTestAPI, '/api/v1.0/data_collectors/test')
 api.add_resource(res.DataCollectorsCountAPI, '/api/v1.0/data_collectors/count')
 api.add_resource(res.DataCollectorActivityResource, '/api/v1.0/data_collectors/activity')
 api.add_resource(res.DataCollectorTypesAPI, '/api/v1.0/data_collector_types')
+api.add_resource(res.DataCollectorTTNAccount, '/api/v1.0/data_collectors/ttn_credentials')
+api.add_resource(res.DataCollectorUserGateways, '/api/v1.0/data_collectors/user_gateways')
 #endregion
 
 #region Devices

--- a/iot_api/user_api/resources/endpoints.py
+++ b/iot_api/user_api/resources/endpoints.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 
 import dateutil.parser as dp
 import requests
-from flask import jsonify, make_response, request, render_template
+from flask import jsonify, make_response, request, render_template, session
 from flask_jwt_extended import (create_access_token, create_refresh_token, jwt_optional, jwt_required, get_jwt_identity,
                                 get_raw_jwt,
                                 jwt_refresh_token_required)
@@ -122,6 +122,11 @@ user_change_password_by_recovery_parser.add_argument("password", help="Missing p
 
 add_recipient_parser = reqparse.RequestParser()
 add_recipient_parser.add_argument("name", help="Missing name attribute.", required=True)
+
+ttn_credentials_parser = reqparse.RequestParser()
+ttn_credentials_parser.add_argument("user", dest="username", help="You have to enter username",
+                          required=True)
+ttn_credentials_parser.add_argument("password", help="You have to enter a password", required=True)
 
 
 # verify if specified username belongs to user with role 'Regular_User'
@@ -1868,6 +1873,60 @@ class DataCollectorTypesAPI(Resource):
         types = DataCollectorType.find_all()
 
         return list(map(lambda type: type.to_json(), types))
+
+class DataCollectorTTNAccount(Resource):
+    @jwt_required
+    def post(self):
+        user_identity = get_jwt_identity()
+        user = User.find_by_username(user_identity)
+
+        if not user or not is_admin_user(user.id):
+            return forbidden()
+
+        data = ttn_credentials_parser.parse_args()
+        ttn_user = data["username"]
+        ttn_password = data["password"]
+        
+        if not ttn_user or not ttn_password:
+            return bad_request("TTN credentials not provided")
+
+        ses = requests.Session()
+        ses.headers['Content-type'] = 'application/json'
+        res = ses.post('https://account.thethingsnetwork.org/api/v2/users/login', data=json.dumps({"username": ttn_user, "password": ttn_password}))
+        ses.get('https://console.thethingsnetwork.org/login')
+
+        if res.status_code != 200:
+            return not_found()
+
+        data_access = ses.get('https://console.thethingsnetwork.org/refresh', timeout=30)
+
+        if data_access.status_code != 200:
+            return internal("couldn't get TTN access data")
+
+        access_token = data_access.json().get('access_token')
+
+        LOG.debug(f"auth_header: Bearer {access_token}")
+        res = ses.get('https://console.thethingsnetwork.org/api/gateways', headers={'Authorization': 'Bearer {}'.format(access_token)}, timeout=30)
+
+        session['user_gateways'] = [{"id":gateway.get('id'), "description":gateway.get('attributes').get('description')} for gateway in res.json()]
+
+        return jsonify({"message": "Credentials processed successfully"})
+
+class DataCollectorUserGateways(Resource):
+    @jwt_required
+    def get(self):
+        user_identity = get_jwt_identity()
+        user = User.find_by_username(user_identity)
+
+        if not user or not is_admin_user(user.id) and not is_regular_user(user.id):
+            return forbidden()
+
+        user_gateways = session.get('user_gateways')
+
+        if not user_gateways:
+            return not_found()
+
+        return user_gateways
 
 
 class DevicesListAPI(Resource):

--- a/iot_api/user_api/resources/endpoints.py
+++ b/iot_api/user_api/resources/endpoints.py
@@ -1904,8 +1904,6 @@ class DataCollectorTTNAccount(Resource):
             return internal("couldn't get TTN access data")
 
         access_token = data_access.json().get('access_token')
-
-        LOG.debug(f"auth_header: Bearer {access_token}")
         res = ses.get('https://console.thethingsnetwork.org/api/gateways', headers={'Authorization': 'Bearer {}'.format(access_token)}, timeout=30)
 
         session['user_gateways'] = [{"id":gateway.get('id'), "description":gateway.get('attributes').get('description')} for gateway in res.json()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ eventlet
 flask_socketio
 kombu
 py3DNS
+flask_socketio
+flask-session


### PR DESCRIPTION
## Changes proposal
- Two methods were added to the API:
    -  POST /api/v1.0/data_collectors/ttn_credentials . Receives an account's TTN credentials, logins to TTN, retrieves the user Gateways from TTN API and saves the gateways on the user session.
     - GET /api/v1.0/data_collectors/user_gateways . Returns Gateways from the user's session.
 - Session management is managed through flask_session.

